### PR TITLE
Allow plugin to register more than once

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,12 +1,12 @@
-const LimitdClient = require('limitd-client');
+'use strict';
+
 const Boom = require('boom');
 const Joi = require('joi');
+const limitdPool = require('./limitd_pool');
+const RateLimitedRequest = require('./rate_limited_request');
+const RateLimitedRequestMap = require('./rate_limited_request_map');
 
-const RateLimitHeaders = function(limit, remaining, reset){
-  this['X-RateLimit-Limit'] = limit;
-  this['X-RateLimit-Remaining'] = remaining;
-  this['X-RateLimit-Reset'] = reset;
-};
+const pendingRequests = new RateLimitedRequestMap();
 
 const schema = Joi.object().keys({
   event: Joi.any().valid(['onRequest', 'onPreAuth', 'onPostAuth', 'onPreHandler']),
@@ -21,8 +21,6 @@ const schema = Joi.object().keys({
   extractKey: Joi.func()
 }).requiredKeys('type', 'event', 'address', 'extractKey');
 
-const pendingRequests = new Map();
-
 function setResponseHeader(request, header, value) {
   if (!request.response) { return; }
 
@@ -33,78 +31,110 @@ function setResponseHeader(request, header, value) {
   }
 }
 
+function setupPreResponseExt(server) {
+  server.ext('onPreResponse', (request, reply) => {
+    const rlRequest = pendingRequests.getAndRemove(request.id);
+
+    if (rlRequest && rlRequest.isConformant()){
+      const headers = rlRequest.getResponseHeaders();
+
+      Object.keys(headers).forEach(
+        key => setResponseHeader(request, key, headers[key]));
+    }
+
+    reply.continue();
+  });
+}
+
+function setupRateLimitEventExt(server, options) {
+  const event = options.event;
+  const type = options.type;
+  const extractKey = options.extractKey;
+  const onError = options.onError;
+
+  const extractKeyAndTakeToken = function(limitd, request, reply, type) {
+    extractKey(request, reply, (err, key) =>{
+      if (err) { return reply(err); }
+
+      limitd.take(type, key, (err, resp) => {
+        if (err){
+          if (onError) { return onError(err, reply); }
+          // by default we don't fail if limitd is unavailable
+          return reply.continue();
+        }
+
+        const rlRequest = new RateLimitedRequest(request.id, resp);
+        const r = pendingRequests.keepWorse(rlRequest);
+
+        if (rlRequest.isConformant()) {
+          return reply.continue();
+        }
+
+        const error = Boom.tooManyRequests();
+        error.output.headers = rlRequest.getResponseHeaders();
+
+        reply(error);
+      });
+    });
+  };
+
+  const getType = function(request, reply, callback) {
+    const type = options.type;
+
+    if (typeof type !== 'function') {
+      return process.nextTick(() => callback(null, type));
+    }
+
+    try {
+      return type(request, (err, type) => {
+        if (err) {
+          return reply(Boom.wrap(err, 500, 'cannot get bucket type'));
+        }
+
+        callback(null, type);
+      });
+    } catch (err) {
+      return reply(Boom.wrap(err, 500, 'cannot get bucket type'));
+    }
+  };
+
+  server.ext(event, (request, reply) => {
+    const limitd = limitdPool.get(options.address);
+
+    // If current response is already not conformant we can stop
+    const currentRlRequest = pendingRequests.get(request.id);
+    if (currentRlRequest && !currentRlRequest.isConformant()) { return; }
+
+    getType(request, reply, (err, type) => {
+      extractKeyAndTakeToken(limitd, request, reply, type);
+    });
+  });
+}
+
+function setupStopExt(server, options) {
+  server.ext('onPostStop', function(server, next) {
+    const limitd = limitdPool.get(options.address);
+    limitd.disconnect();
+    next();
+  });
+}
+
+function setupStartExt(server, options) {
+  server.ext('onPreStart', function(server, next) {
+    const limitd = limitdPool.prepare(options.address);
+    next();
+  });
+}
+
 exports.register = function (server, options, next) {
+
   Joi.validate(options, schema, { abortEarly: false }, (err, processedOptions) => {
     if (err) { return next(err); }
 
-    const event = processedOptions.event;
-    const extractKey = processedOptions.extractKey;
-    const onError = processedOptions.onError;
-    const limitd = new LimitdClient(processedOptions.address);
-
-    limitd.on('error', () => {
-      // ignore. what to do on error is decided by on error
-    });
-
-    const extractKeyAndTakeToken = function(request, reply, type) {
-      extractKey(request, reply, (err, key) =>{
-        if (err) { return reply(err); }
-
-        limitd.take(type, key, (err, resp) => {
-          if (err){
-            if (onError) { return onError(err, reply); }
-            // by default we don't fail if limitd is unavailable
-            return reply.continue();
-          }
-
-          const headers = new RateLimitHeaders(resp.limit, resp.remaining, resp.reset);
-
-          if (resp.conformant) {
-            pendingRequests.set(request.id, headers);
-            return reply.continue();
-          }
-
-          const error = Boom.tooManyRequests();
-          error.output.headers = headers;
-
-          reply(error);
-        });
-      });
-    };
-
-    const getType = function(request, reply, callback) {
-      const type = processedOptions.type;
-      if (typeof type !== 'function') {
-        return process.nextTick(() => callback(null, type));
-      }
-
-      try {
-        return type(request, (err, type) => {
-          if (err) {
-            return reply(Boom.wrap(err, 500, 'cannot get bucket type'));
-          }
-
-          callback(null, type);
-        });
-      } catch (err) {
-        return reply(Boom.wrap(err, 500, 'cannot get bucket type'));
-      }
-    };
-
-    server.ext(event, (request, reply) =>
-      getType(request, reply, (err, type) => {
-        extractKeyAndTakeToken(request, reply, type);
-      }));
-
-    server.ext('onPreResponse', (request, reply) => {
-      const headers = pendingRequests.get(request.id);
-      if (headers){
-        Object.keys(headers).forEach(
-          key => setResponseHeader(request, key, headers[key]));
-      }
-
-      reply.continue();
-    });
+    setupStartExt(server, processedOptions);
+    setupStopExt(server, processedOptions);
+    setupRateLimitEventExt(server, processedOptions);
+    setupPreResponseExt(server);
 
     next();
   });
@@ -112,5 +142,6 @@ exports.register = function (server, options, next) {
 };
 
 exports.register.attributes = {
-  pkg: require('../package.json')
+  pkg: require('../package.json'),
+  multiple: true
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,16 @@ const schema = Joi.object().keys({
 
 const pendingRequests = new Map();
 
+function setResponseHeader(request, header, value) {
+  if (!request.response) { return; }
+
+  if (request.response.isBoom) {
+    request.response.output.headers[header] = value;
+  } else {
+    request.response.header(header, value);
+  }
+}
+
 exports.register = function (server, options, next) {
   Joi.validate(options, schema, { abortEarly: false }, (err, processedOptions) => {
     if (err) { return next(err); }
@@ -90,7 +100,7 @@ exports.register = function (server, options, next) {
       const headers = pendingRequests.get(request.id);
       if (headers){
         Object.keys(headers).forEach(
-          key => request.response.header(key, headers[key]));
+          key => setResponseHeader(request, key, headers[key]));
       }
 
       reply.continue();

--- a/lib/limitd_pool.js
+++ b/lib/limitd_pool.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const LimitdClient = require('limitd-client');
+const clients = new Map();
+
+exports.prepare = function(address) {
+  const limitd = new LimitdClient(address);
+
+  limitd.on('close', () => {
+    clients.delete(address);
+  });
+
+  limitd.on('error', () => {
+    // ignore. what to do on error is decided by on error
+  });
+
+  clients.set(address, limitd);
+
+  return limitd;
+};
+
+// We can register the plugin as many times as we
+// want, lets keep the min number of opened connections
+exports.get = function get(address) {
+  return clients.get(address);
+};

--- a/lib/rate_limit_headers.js
+++ b/lib/rate_limit_headers.js
@@ -1,0 +1,9 @@
+'use strict';
+
+function RateLimitHeaders(limit, remaining, reset){
+  this['X-RateLimit-Limit'] = limit;
+  this['X-RateLimit-Remaining'] = remaining;
+  this['X-RateLimit-Reset'] = reset;
+};
+
+module.exports = RateLimitHeaders;

--- a/lib/rate_limited_request.js
+++ b/lib/rate_limited_request.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const RateLimitHeaders = require('./rate_limit_headers');
+
+function RateLimitedRequest(id, data) {
+  this.id = id;
+  this.remaining = data.remaining;
+  this.conformant = data.conformant;
+  this.responseHeaders = new RateLimitHeaders(data.limit, data.remaining, data.reset);
+};
+
+RateLimitedRequest.prototype.hasMoreRemainingThan = function(otherRlResponse) {
+  return this.remaining > otherRlResponse.remaining;
+};
+
+RateLimitedRequest.prototype.isConformant = function() {
+  return this.conformant;
+};
+
+RateLimitedRequest.prototype.getResponseHeaders = function() {
+  return this.responseHeaders;
+};
+
+module.exports = RateLimitedRequest;

--- a/lib/rate_limited_request_map.js
+++ b/lib/rate_limited_request_map.js
@@ -1,0 +1,41 @@
+'use strict';
+
+function RateLimitedRequestMap() {
+  this._requests = new Map();
+}
+
+/**
+ * Keeps rate limited request which has the worse limit:
+ *
+ *  - If when this function is called there is a request with the same id as
+ * `rlRequest.id`, it keeps the request with less remaining tokens and discard
+ * the other one.
+ *
+ *  - If when this function is called there is not a request for `rlRequest.id`
+ * it adds the given request.
+ */
+RateLimitedRequestMap.prototype.keepWorse = function keepWorse(rlRequest) {
+  if (!rlRequest) { return; }
+
+  const requestId = rlRequest.id;
+  const old = this._requests.get(requestId);
+
+  if (old && rlRequest.hasMoreRemainingThan(old)) { return old; }
+
+  this._requests.set(requestId, rlRequest);
+
+  return rlRequest;
+};
+
+RateLimitedRequestMap.prototype.get = function get(requestId) {
+  return this._requests.get(requestId);
+};
+
+RateLimitedRequestMap.prototype.getAndRemove = function getAndRemove(requestId) {
+  const rlRequest = this.get(requestId);
+  this._requests.delete(requestId);
+
+  return rlRequest;
+};
+
+module.exports = RateLimitedRequestMap;

--- a/test/limitdConfig/settings.yml
+++ b/test/limitdConfig/settings.yml
@@ -7,3 +7,10 @@ buckets:
     interval: 10
   empty:
     size: 0
+  bucket_3:
+    size: 3
+    per_hour: 1
+  bucket_4:
+    size: 10
+    per_hour: 1
+

--- a/test/limitdServer.js
+++ b/test/limitdServer.js
@@ -1,13 +1,16 @@
-var rimraf = require('rimraf');
-var path  = require('path');
-var xtend = require('xtend');
-var LimitdServer = require('limitd').Server;
-var LimitdClient = require('limitd-client');
+'use strict';
 
-var server;
+const rimraf = require('rimraf');
+const path  = require('path');
+const xtend = require('xtend');
+const LimitdServer = require('limitd').Server;
+const LimitdClient = require('limitd-client');
+
+let server;
+let instanceNumber = 0;
 
 exports.start = function(done){
-  var db_file = path.join(__dirname, 'dbs', 'server.tests.db');
+  const db_file = path.join(__dirname, 'dbs', `server.${instanceNumber++}.tests.db`);
 
   try{
     rimraf.sync(db_file);
@@ -17,13 +20,17 @@ exports.start = function(done){
 
   server.start(function (err, address) {
     if (err) { return done(err); }
-    client = new LimitdClient({ host: address.address, port: address.port });
+    let client = new LimitdClient({ host: address.address, port: address.port });
     client.once('connect', function(){
+      client.disconnect();
+
       done(address);
     });
   });
 };
 
-exports.stop = function () {
+exports.stop = function (done) {
+  server.once('close', () => done());
+
   server.stop();
 };

--- a/test/server.js
+++ b/test/server.js
@@ -1,9 +1,10 @@
 var Hapi = require('hapi');
 var plugin = require('../');
+var Boom = require('boom');
 
 var server;
 
-exports.start = function(pluginOptions, done){
+exports.start = function(replyOptions, pluginOptions, done){
   server = new Hapi.Server();
   server.connection({
     host: 'localhost',
@@ -20,7 +21,11 @@ exports.start = function(pluginOptions, done){
       method: 'POST',
       path:'/users',
       handler: function (request, reply) {
-        reply('created');
+        if (replyOptions.replyError) {
+          reply(Boom.forbidden('You cannot access Zion'));
+        } else {
+          reply('created');
+        }
       }
     });
 

--- a/test/server.js
+++ b/test/server.js
@@ -6,31 +6,40 @@ var server;
 
 exports.start = function(replyOptions, pluginOptions, done){
   server = new Hapi.Server();
+
   server.connection({
     host: 'localhost',
     port: 3001,
   });
 
-  server.register({
-    register: plugin,
-    options: pluginOptions,
-  }, function (err) {
-    if (err) { throw err; }
-
-    server.route({
-      method: 'POST',
-      path:'/users',
-      handler: function (request, reply) {
-        if (replyOptions.replyError) {
-          reply(Boom.forbidden('You cannot access Zion'));
-        } else {
-          reply('created');
-        }
+  server.route({
+    method: 'POST',
+    path:'/users',
+    handler: function (request, reply) {
+      if (replyOptions.replyError) {
+        reply(Boom.forbidden('You cannot access Zion'));
+      } else {
+        reply('created');
       }
-    });
+    }
+  });
+
+  const allPluginOptions = Array.isArray(pluginOptions) ? pluginOptions : [ pluginOptions ];
+
+  const plugins = allPluginOptions.map(pluginOptions => this.desc(pluginOptions));
+
+  server.register(plugins, err => {
+    if (err) { throw err; }
 
     server.start(done);
   });
+};
+
+exports.desc = function(pluginOptions) {
+  return {
+    register: plugin,
+    options: pluginOptions,
+  };
 };
 
 exports.inject = function(){


### PR DESCRIPTION
- Use as few connections as possible
- Short circuit evaluation: stop once a response is evaluated as not conformat
- Send the lowest remaining as limit header on responses

Closes #2