### PR TITLE
remove hapi from peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,5 @@
     "mocha": "^2.1.0",
     "rimraf": "^2.3.1",
     "xtend": "^4.0.0"
-  },
-  "peerDependencies": {
-    "hapi": "11.x.x"
   }
 }


### PR DESCRIPTION
Peer dependencies are deprecated from node.js and this is preventing us to upgrade to latest version of hapi.