### PR TITLE
don't remove limitd client on close

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -48,7 +48,6 @@ function setupPreResponseExt(server) {
       Object.keys(headers).forEach(
         key => setResponseHeader(request, key, headers[key]));
     }
-
     reply.continue();
   });
 }
@@ -62,6 +61,11 @@ function setupRateLimitEventExt(server, options) {
   const extractKeyAndTakeToken = function(limitd, request, reply, type) {
     extractKey(request, reply, (err, key) =>{
       if (err) { return reply(err); }
+
+      if (!limitd) {
+        // limitd is not connected, do not fail!
+        return reply.continue();
+      }
 
       limitd.take(type, key, (err, resp) => {
         if (err){
@@ -106,12 +110,12 @@ function setupRateLimitEventExt(server, options) {
   };
 
   server.ext(event, (request, reply) => {
-    const limitd = limitdPool.get(options.address);
 
     // If current response is already not conformant we can stop
     const currentRlRequest = pendingRequests.get(request.id);
     if (currentRlRequest && !currentRlRequest.isConformant()) { return; }
 
+    const limitd = limitdPool.get(options.address);
     getType(request, reply, (err, type) => {
       extractKeyAndTakeToken(limitd, request, reply, type);
     });
@@ -121,7 +125,9 @@ function setupRateLimitEventExt(server, options) {
 function setupStopExt(server, options) {
   server.ext('onPostStop', function(server, next) {
     const limitd = limitdPool.get(options.address);
-    limitd.disconnect();
+    if (limitd) {
+      limitd.disconnect();
+    }
     next();
   });
 }

--- a/lib/limitd_pool.js
+++ b/lib/limitd_pool.js
@@ -3,18 +3,38 @@
 const LimitdClient = require('limitd-client');
 const clients = new Map();
 
-exports.prepare = function(address) {
-  const limitd = new LimitdClient({hosts: [address]});
+function addToMap(address, limitd) {
+  clients.set(address, limitd);
+}
 
-  limitd.on('close', () => {
-    clients.delete(address);
-  });
+exports.prepare = function(address) {
+  let options = address;
+
+  if (typeof address === 'object' && 'host' in address) {
+    options  = { hosts: [ address ] };
+  }
+
+  const limitd = new LimitdClient(options);
 
   limitd.on('error', () => {
     // ignore. what to do on error is decided by on error
   });
 
-  clients.set(address, limitd);
+  limitd.on('close', () => {
+    clients.delete(address);
+  });
+
+  // When limitd gets disconnected, it will emit 'reconnect' events while it is trying to get connected back.
+  limitd.on('reconnect', ()=> {
+    clients.delete(address);
+  });
+
+  //  limitd gets connected or reconnected
+  limitd.on('ready', ()=> {
+    addToMap(address, limitd);
+  });
+
+  addToMap(address, limitd);
 
   return limitd;
 };

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "limitd-client": "^1.13.1"
   },
   "devDependencies": {
+    "async": "^2.1.4",
     "chai": "^2.1.0",
     "hapi": "^15.2.0",
     "js-yaml": "^3.2.7",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "boom": "^2.6.1",
     "joi": "^7.0.1",
-    "limitd-client": "^1.10.1"
+    "limitd-client": "^1.13.1"
   },
   "devDependencies": {
     "chai": "^2.1.0",

--- a/test/limitdConfig/settings.yml
+++ b/test/limitdConfig/settings.yml
@@ -1,4 +1,3 @@
-port: 9001
 
 buckets:
   users:

--- a/test/limitdServer.js
+++ b/test/limitdServer.js
@@ -6,31 +6,55 @@ const xtend = require('xtend');
 const LimitdServer = require('limitd').Server;
 const LimitdClient = require('limitd-client');
 
-let server;
 let instanceNumber = 0;
 
-exports.start = function(done){
-  const db_file = path.join(__dirname, 'dbs', `server.${instanceNumber++}.tests.db`);
+function create(port) {
 
-  try{
-    rimraf.sync(db_file);
-  } catch(err){}
+  port = port || 9001;
 
-  server = new LimitdServer(xtend({db: db_file}, require('./limitdConfig')));
+  let server;
+  
+  return {
 
-  server.start(function (err, address) {
-    if (err) { return done(err); }
-    let client = new LimitdClient({ hosts: [ address ] });
-    client.once('connect', function(){
-      client.disconnect();
+    start: function(done) {
+      const db_file = path.join(__dirname, 'dbs', `server.${instanceNumber++}.tests.db`);
 
-      done(address);
-    });
-  });
+      try{
+        rimraf.sync(db_file);
+      } catch(err){}
+
+      server = new LimitdServer(xtend({db: db_file, port: port}, require('./limitdConfig')));
+
+      server.start(function (err, address) {
+        if (err) { return done(err); }
+
+        let client = new LimitdClient(`limitd://127.0.0.1:${port}`);
+        client.once('connect', function(){
+          client.disconnect();
+          done(address);
+        });
+      });
+    },
+
+    stop: function (done) {
+      server.once('close', function() {
+        done();
+      });
+      server.stop();
+    }
+  };
+}
+
+exports.create = create;
+
+// backguard compatibility
+const instance = create();
+
+exports.start = function(done) {
+  return instance.start(done);
 };
 
-exports.stop = function (done) {
-  server.once('close', () => done());
-
-  server.stop();
+exports.stop = function(done) {
+  return instance.stop(done);
 };
+

--- a/test/limitdServer.js
+++ b/test/limitdServer.js
@@ -16,7 +16,7 @@ function create(port) {
   
   return {
 
-    start: function(done) {
+    start: function(cb) {
       const db_file = path.join(__dirname, 'dbs', `server.${instanceNumber++}.tests.db`);
 
       try{
@@ -26,19 +26,19 @@ function create(port) {
       server = new LimitdServer(xtend({db: db_file, port: port}, require('./limitdConfig')));
 
       server.start(function (err, address) {
-        if (err) { return done(err); }
+        if (err) { return cb(err); }
 
         let client = new LimitdClient(`limitd://127.0.0.1:${port}`);
         client.once('connect', function(){
           client.disconnect();
-          done(address);
+          cb(null, address);
         });
       });
     },
 
-    stop: function (done) {
+    stop: function (cb) {
       server.once('close', function() {
-        done();
+        cb();
       });
       server.stop();
     }
@@ -51,7 +51,9 @@ exports.create = create;
 const instance = create();
 
 exports.start = function(done) {
-  return instance.start(done);
+  return instance.start(function(err, address) {
+    done(address);
+  });
 };
 
 exports.stop = function(done) {

--- a/test/limitd_pool.js
+++ b/test/limitd_pool.js
@@ -1,0 +1,159 @@
+'use strict';
+
+const expect        = require('chai').expect;
+const limitdPool    = require('../lib/limitd_pool');
+const limitdServer  = require('./limitdServer');
+const LimitdClient  = require('limitd-client');
+
+describe('limitd_pool', function() {
+
+  describe('connected to one limitd server instance', function() {
+
+    let server;
+    let address;
+
+    function stopServer(done) {
+      server.stop(function() {
+        setTimeout(done, 300);
+      });
+    }
+
+    function startServer(done) {
+      server.start(function() {
+        setTimeout(done, 300);
+      });
+    }
+
+    before(function() {
+      // create server instance
+      server = limitdServer.create(9001);
+      address = 'limitd://127.0.0.1:9001';
+      limitdPool.prepare(address);
+    });
+
+    describe('when limitd server is running', function() {
+
+      before(startServer);
+
+      it('the get method should return limitd client instance', function() {
+        const client = limitdPool.get(address);
+        expect(client).to.be.an.instanceof(LimitdClient);
+      });
+
+      describe('if limitd server gets down', function() {
+        
+        before(stopServer);
+
+        it('get method should return undefined', function() {
+          const client = limitdPool.get(address);
+          expect(client).to.be.undefined;
+        });
+
+        describe('and if limitd gets up again', function() {
+
+          before(startServer);
+
+          it('get method should return limitd client instance', function() {
+            const client = limitdPool.get(address);
+            expect(client).to.be.an.instanceof(LimitdClient);
+          });
+        });
+      });
+    });
+
+    after(stopServer);
+  });
+
+  describe('connected to many limitd server instances', function() {
+
+    let servers = [];
+    let addresses = [];
+
+    before (function() {
+      // create all limitd server instances.
+      var count = 3;
+      for(let n=0; n<count; n++) {  
+        let server = limitdServer.create(9002 + n);
+        servers.push(server);
+        addresses.push(`limitd://127.0.0.1:${9002 + n}`);
+      }
+
+      limitdPool.prepare(addresses);
+    });
+
+    describe('when all limitd servers are running', function() {
+
+      before(function(done) {
+        servers[0].start(function () {
+          servers[1].start(function () {
+            servers[2].start(function () {
+              setTimeout(done, 300);
+            });
+          });
+        });
+      });
+
+
+      it('the get method should return a limitd client instance', function() {
+        const client = limitdPool.get(addresses);
+        expect(client).to.be.an.instanceof(LimitdClient);
+      });
+
+      describe('when just one server is running', function() {
+        
+        before(function(done) {
+          servers[0].stop(function () {
+            servers[1].stop(function () {
+              setTimeout(done, 300);
+            });
+          });
+        });
+
+        it('the get method should return a limitd instance', function() {
+          const client = limitdPool.get(addresses);
+          expect(client).to.be.an.instanceof(LimitdClient);
+        });
+
+        describe('when all limitd servers are down', function() {
+          
+          before(function(done) {
+            servers[2].stop(function () {
+              setTimeout(done, 300);
+            });
+          });
+
+          it('get method should return undefined', function() {
+            const client = limitdPool.get(addresses);
+            expect(client).to.be.undefined;
+          });
+
+          describe('and if a limitd server gets up again', function() {
+
+            before(function(done) {
+              servers[1].start(function () {
+                setTimeout(done, 300);
+              });
+            });
+
+            it('get method should return a limitd instance', function() {
+              const client = limitdPool.get(addresses);
+              expect(client).to.be.an.instanceof(LimitdClient);
+            });
+          });
+        });
+      });
+    });
+
+    after(function(done) {
+      // release resources
+      let count = servers.length;
+      servers.forEach((server) => {
+        server.stop(function cb() {
+          if (--count === 0) {
+            return done();
+          }
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
don't remove limitd client on close

It is not necessary to remove the client instance. And when it becomes removed, Patova throws exceptions on some functions like:

https://github.com/dschenkelman/patova/blob/912e50630394dfc3959155b44cc4cd778dcb2ad2/lib/index.js#L66

and

https://github.com/dschenkelman/patova/blob/912e50630394dfc3959155b44cc4cd778dcb2ad2/lib/index.js#L124

