### PR TITLE
Bump supported hapi version to 16.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "xtend": "^4.0.0"
   },
   "peerDependencies": {
-    "hapi": ">=11.x.x <=15.x.x"
+    "hapi": ">=11.x.x <=16.x.x"
   }
 }


### PR DESCRIPTION
Tested on 16.0 and 16.1.1 worked well in both versions.