### PR TITLE
Remove useless code

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -115,10 +115,6 @@ function setupRateLimitEventExt(server, options) {
 
   server.ext(event, (request, reply) => {
     // This handler is going to be called one time per registration of patova
-    // If current response is already not conformant we can stop
-    const currentRequestLimit = request.plugins.patova && request.plugins.patova.limit
-    if (currentRequestLimit && !currentRequestLimit.conformant) { return; }
-
     getType(request, reply, (err, type) => {
       extractKeyAndTakeToken(options.limitd, request, reply, type);
     });


### PR DESCRIPTION
According to docs if we call reply(error) the request lifecycle
is interrumpted except for `onPostHandler` and `onPreResponse`
the check (which had a bug) was meant to handle those cases
but the plugin cannot be registered for those extention points
as per options validation.


> reply - the reply interface which is used to return control back to the framework. To continue normal execution of the request lifecycle, reply.continue() must be called. If the extension type is 'onPostHandler' or 'onPreResponse', a single argument passed to reply.continue() will override the current set response (including all headers) but will not stop the request lifecycle execution. To abort processing and return a response to the client, call reply(value) where value is an error or any other valid response.
