### PR TITLE
Add response handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The object has the following schema (validated [here](./lib/index.js) using [Joi
 * `event: String` - The name of the extension point in the request lifecycle when the bucket check must be performed. Options are `"onRequest"`, `"onPreAuth"`, `"onPostAuth"`,`"onPreHandler"` (anything before the request).
 * `type: String|(request, callback) => ()` - Either the bucket type as a string or a function. If you use a function, it will be called for every request, this function must invoke the callback function when it is finished.
 * `limitd`: an instance of limitd client
-* `extractKey: (request, done) => ()` - A function that receives the `request` and a callback `done`.
+* `extractKey: (request, reply, done) => ()` - A function that receives the `request` and a callback `done`.
   * `request: Request` - The hapi.js [request object](http://hapijs.com/api#request-object).
   * `reply: Reply` - The hapi.js [reply interface](http://hapijs.com/api#reply-interface). Useful if you want to skip the check.
   * `done: (err: Error, key: String)` - A function that takes an error as the first parameter and the bucket key as the second parameter.
@@ -48,6 +48,15 @@ The object has the following schema (validated [here](./lib/index.js) using [Joi
   * `error: Error` - The error that occurred.
   * `reply: Reply` - The hapi.js [reply interface](http://hapijs.com/api#reply-interface).
   > If an error occurs and no function is provided, the request lifecycle continues normally as if there was no token bucket restriction. This is a useful default behavior in case the limitd server goes down.
+* `limitResponseHandler: (limitResult, req, reply) => ()` A function that receives the result of limit checking against limitd, the `request` and the reply interface and is responsible for sending the handling
+how to respond to the customer. This function will be called only when non-conformant limits are detected.
+  * `limitResult: The result object from limit verification`:
+      * conformant: whether the response was conformant (is always `false` for this handler, but is kept for consistency)
+      * limit: the limit of tokens that the bucket accepts
+      * remaining: number of remaining tokens (is always 0 for this handler, but is kept for consistency)
+      * reset: next reset timestamp
+  * `request: Request` - The hapi.js [request object](http://hapijs.com/api#request-object).
+  * `reply: Reply` - The hapi.js [reply interface](http://hapijs.com/api#reply-interface). Useful if you want to skip the check.
 
 ## Contributing
 Feel free to open issues with questions/bugs/features. PRs are also welcome.

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,6 +44,17 @@ function getMinimumLimit(limit1, limit2) {
   if (!limit1) { return limit2; }
   if (!limit2) { return limit1; }
 
+  // Even if we have decided not to answer with an error immediately,
+  // if some limit is non conformat then we will consider it the
+  // minimum applicable
+  if (!limit1.conformant && limit2.conformant) {
+    return limit1;
+  }
+
+  if (limit1.conformant && !limit2.conformant) {
+    return limit2;
+  }
+
   if (limit1 && limit2.remaining > limit1.remaining) {
     return limit1;
   }
@@ -88,12 +99,12 @@ function setupRateLimitEventExt(server, options) {
         request.plugins.patova = request.plugins.patova || {};
         request.plugins.patova.limit = newMinimumLimitResponse;
 
-        if (newMinimumLimitResponse.conformant) {
+        if (currentLimitResponse.conformant) {
           // We continue only if the request is conformat so far
           return reply.continue();
         }
 
-        limitResponseHandler(newMinimumLimitResponse, request, reply);
+        limitResponseHandler(currentLimitResponse, request, reply);
       });
     });
   };

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,8 @@ const schema = Joi.object().keys({
   type: [Joi.string(), Joi.func()],
   limitd: Joi.object(),
   onError: Joi.func(),
-  extractKey: Joi.func()
+  extractKey: Joi.func(),
+  limitResponseHandler: Joi.func()
 }).requiredKeys('type', 'event', 'limitd', 'extractKey');
 
 function setResponseHeader(request, header, value) {
@@ -55,6 +56,16 @@ function setupRateLimitEventExt(server, options) {
   const extractKey = options.extractKey;
   const onError = options.onError;
 
+  const limitResponseHandler = options.limitResponseHandler || ((result, req, reply) => {
+    const error = Boom.tooManyRequests();
+    error.output.headers = new RateLimitHeaders(
+      result.limit,
+      result.remaining,
+      result.reset);
+
+    reply(error);
+  });
+
   const extractKeyAndTakeToken = function(limitd, request, reply, type) {
     extractKey(request, reply, (err, key) =>{
       if (err) { return reply(err); }
@@ -82,13 +93,7 @@ function setupRateLimitEventExt(server, options) {
           return reply.continue();
         }
 
-        const error = Boom.tooManyRequests();
-        error.output.headers = new RateLimitHeaders(
-          newMinimumLimitResponse.limit,
-          newMinimumLimitResponse.remaining,
-          newMinimumLimitResponse.reset);
-
-        reply(error);
+        limitResponseHandler(newMinimumLimitResponse, request, reply);
       });
     });
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patova",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "A limitd plugin for hapi.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### What?
Supports accepting a response handler function in Patova,
this allows us to implement things as training mode based on
Patova's features.

### Why?
Sending the rate limit  headers is not the only possible reaction
on error, we might even need to send different headers based on
the limit (for example global vs. local). There are other possible actions
for example not failing the request but limiting the resources put in it
or moving it to a different work-stream it.

One use case is implementing "training mode" where we want to send
the rate limit header but avoid completelly failing the request, that
would let consumers prepare.